### PR TITLE
convert camelcase model names to underscore for DB

### DIFF
--- a/src/Commands/ScaffoldMakeCommand.php
+++ b/src/Commands/ScaffoldMakeCommand.php
@@ -231,9 +231,9 @@ class ScaffoldMakeCommand extends Command
         // Name[1] = Tweets
         $names['Names'] = str_plural(ucfirst($args_name));
         // Name[2] = tweets
-        $names['names'] = str_plural(strtolower($args_name));
+        $names['names'] = str_plural(strtolower(preg_replace('/(?<!^)([A-Z])/', '_$1', $args_name)));
         // Name[3] = tweet
-        $names['name'] = str_singular(strtolower($args_name));
+        $names['name'] = str_singular(strtolower(preg_replace('/(?<!^)([A-Z])/', '_$1', $args_name)));
 
 
         if (!isset($names[$config])) {


### PR DESCRIPTION
Creating a scaffold for DocumentType creates a migration that generates a `documenttypes` table, but Laravel expects `document_types`. This fixes that, also changes the suggested route from documenttypes to document_type, may not be preferred, but it's a scaffold.