### PR TITLE
Update MakeModel.php to work with Laravel 5.1

### DIFF
--- a/src/Makes/MakeModel.php
+++ b/src/Makes/MakeModel.php
@@ -32,8 +32,7 @@ class MakeModel {
 
         if (! $this->files->exists($modelPath)) {
             $this->scaffoldCommandObj->call('make:model', [
-                'name' => $name,
-                '--no-migration' => true
+                'name' => $name
             ]);
         }
 


### PR DESCRIPTION
Laravel 5.1 no longer supports the --no-migration flag. It's not even needed, as migrations aren't made by default not.