### PR TITLE
fixed bug on Laravel 5.1.2

### DIFF
--- a/src/Makes/MakeModel.php
+++ b/src/Makes/MakeModel.php
@@ -33,7 +33,6 @@ class MakeModel {
         if (! $this->files->exists($modelPath)) {
             $this->scaffoldCommandObj->call('make:model', [
                 'name' => $name,
-                '--no-migration' => true
             ]);
         }
 


### PR DESCRIPTION
This fix solves the “—no-migration" option does not exist.” error